### PR TITLE
[feature/systemsdev-3038] Minimal changes to get to PHP 8.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "lucatume/function-mocker": "^1.3",
     "symfony/dom-crawler": "^5.0",
     "symfony/css-selector": "^5.0",
-    "phpunit/phpunit": "^7.5"
+    "phpunit/phpunit": "^8.5"
   },
   "autoload": {
     "classmap": [
@@ -30,5 +30,11 @@
       "phpunit/Mocks",
       "phpunit/stubs"
     ]
+  },
+  "config": {
+    "sort-packages": true,
+    "platform": {
+      "php": "7.4"
+    }
   }
 }

--- a/phpunit/otgs-testcase.php
+++ b/phpunit/otgs-testcase.php
@@ -24,19 +24,19 @@ abstract class OTGS_TestCase extends PHPUnit\Framework\TestCase {
 	/** @var LegacyWPCore */
 	protected $mocked_wp_core_functions;
 
-	public static function setupBeforeClass() {
+	public static function setupBeforeClass(): void {
 		$_GET  = array();
 		$_POST = array();
 	}
 
-	public function setUp() {
+	public function setUp(): void {
 		FunctionMocker::setUp();
 		parent::setUp();
 		WP_Mock::setUp();
 		$this->stubs = new OTGS_Stubs( $this );
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		unset( $this->stubs );
 		WP_Mock::tearDown();
 		Mockery::close();


### PR DESCRIPTION
Minimal changes to get to PHP 8.0 compatibility. Sets the minimal PHP requirement to 7.2.